### PR TITLE
Add debug symbols and fix a possible segfault.

### DIFF
--- a/graph_app/bc/BC.cpp
+++ b/graph_app/bc/BC.cpp
@@ -540,7 +540,7 @@ int shutdown()
     // release resources
     if( cmd_queue ) clReleaseCommandQueue( cmd_queue );
     if( context )   clReleaseContext( context );
-    if( device_list ) delete device_list;
+    if( device_list ) delete[] device_list;
 
     // reset all variables
     cmd_queue = 0;

--- a/graph_app/bc/BC.cpp
+++ b/graph_app/bc/BC.cpp
@@ -134,6 +134,7 @@ int main(int argc, char **argv){
     if(err != CL_SUCCESS) { fprintf(stderr, "ERROR: clCreateProgramWithSource() => %d\n", err); return -1; }
 	
     err = clBuildProgram(prog, 0, NULL, NULL, NULL, NULL);
+    if (err != CL_SUCCESS)
     { // show warnings/errors
         static char log[65536]; 
 		memset(log, 0, sizeof(log));

--- a/graph_app/bc/BC.h
+++ b/graph_app/bc/BC.h
@@ -107,7 +107,7 @@ csr_array * parseCOO(char* tmpchar, int *p_num_nodes, int *p_num_edges, bool dir
 	int cnt = 0;
 	int cnt1 = 0;
 	unsigned int lineno = 0;
-	char line[128], sp[2], a, p;
+	char line[128], sp[3], a, p;
 	int num_nodes = 0, num_edges = 0;
 	
 	FILE *fptr;

--- a/graph_app/bc/makefile
+++ b/graph_app/bc/makefile
@@ -57,7 +57,7 @@
 include ../../common/make.config
 
 CC = g++
-CC_FLAGS = -O3 -Wall
+CC_FLAGS = -g -O3 -Wall
 
 EXE = bc
 

--- a/graph_app/color/coloring_max.cpp
+++ b/graph_app/color/coloring_max.cpp
@@ -149,6 +149,7 @@ int main(int argc, char **argv){
 												
     if(err != CL_SUCCESS) { fprintf(stderr, "ERROR: clCreateProgramWithSource() => %d\n", err); return -1; }
     err = clBuildProgram(prog, 0, NULL, NULL, NULL, NULL);
+    if (err != CL_SUCCESS)
     { // show warnings/errors
         static char log[65536]; 
 		memset(log, 0, sizeof(log));

--- a/graph_app/color/coloring_max.cpp
+++ b/graph_app/color/coloring_max.cpp
@@ -458,7 +458,7 @@ int shutdown()
     // release resources
     if( cmd_queue ) clReleaseCommandQueue( cmd_queue );
     if( context ) clReleaseContext( context );
-    if( device_list ) delete device_list;
+    if( device_list ) delete[] device_list;
 
     // reset all variables
     cmd_queue = 0;

--- a/graph_app/color/makefile
+++ b/graph_app/color/makefile
@@ -57,7 +57,7 @@
 include ../../common/make.config
 
 CC = g++
-CC_FLAGS = -O3 -Wall
+CC_FLAGS = -g -O3 -Wall
 
 EXE = coloring_max
 EXE_MM = coloring_maxmin

--- a/graph_app/fw/Floyd-Warshall.cpp
+++ b/graph_app/fw/Floyd-Warshall.cpp
@@ -331,7 +331,7 @@ int* parse_graph_file(int *num_nodes, int *num_edges, char* tmpchar){
     int *adjmatrix;
     int cnt = 0;
     unsigned int lineno = 0;
-    char line[128], sp[2], a, p;
+    char line[128], sp[3], a, p;
 	
     FILE *fptr;
 
@@ -473,7 +473,7 @@ int shutdown()
     // release resources
     if( cmd_queue ) clReleaseCommandQueue( cmd_queue );
     if( context ) clReleaseContext( context );
-    if( device_list ) delete device_list;
+    if( device_list ) delete[] device_list;
 
     // reset all variables
     cmd_queue = 0;

--- a/graph_app/fw/Floyd-Warshall.cpp
+++ b/graph_app/fw/Floyd-Warshall.cpp
@@ -155,6 +155,7 @@ int main(int argc, char **argv){
     cl_program prog = clCreateProgramWithSource(context, 1, slist, NULL, &err);
     if(err != CL_SUCCESS) { fprintf(stderr, "ERROR: clCreateProgramWithSource() => %d\n", err); return -1; }
     err = clBuildProgram(prog, 0, NULL, NULL, NULL, NULL);
+    if (err != CL_SUCCESS)
     { // show warnings/errors
 	  static char log[65536]; 
       memset(log, 0, sizeof(log));

--- a/graph_app/fw/makefile
+++ b/graph_app/fw/makefile
@@ -57,7 +57,7 @@
 include ../../common/make.config
 
 CC = g++
-CC_FLAGS = -O3 -Wall
+CC_FLAGS = -g -O3 -Wall
 
 EXE = floyd-warshall
 

--- a/graph_app/mis/mis.cpp
+++ b/graph_app/mis/mis.cpp
@@ -490,7 +490,7 @@ int shutdown()
     // release resources
     if( cmd_queue ) clReleaseCommandQueue( cmd_queue );
     if( context ) clReleaseContext( context );
-    if( device_list ) delete device_list;
+    if( device_list ) delete[] device_list;
 
     // reset all variables
     cmd_queue = 0;

--- a/graph_app/mis/mis.cpp
+++ b/graph_app/mis/mis.cpp
@@ -147,6 +147,7 @@ int main(int argc, char **argv){
     cl_program prog = clCreateProgramWithSource(context, 1, slist, NULL, &err);
     if(err != CL_SUCCESS) { printf("ERROR: clCreateProgramWithSource() => %d\n", err); return -1; }
     err = clBuildProgram(prog, 0, NULL, NULL, NULL, NULL);
+    if (err != CL_SUCCESS)
     { 
       static char log[65536]; 
       memset(log, 0, sizeof(log));

--- a/graph_app/prk/makefile
+++ b/graph_app/prk/makefile
@@ -56,7 +56,7 @@
 
 include ../../common/make.config
 CC = g++
-CC_FLAGS = -O3 -Wall
+CC_FLAGS = -g -O3 -Wall
 
 EXE        = pagerank
 EXE_SPARSE = pagerank_spmv

--- a/graph_app/prk/pagerank.cpp
+++ b/graph_app/prk/pagerank.cpp
@@ -137,6 +137,7 @@ int main(int argc, char **argv){
     cl_program prog = clCreateProgramWithSource(context, 1, slist, NULL, &err);
     if(err != CL_SUCCESS) { fprintf(stderr, "ERROR: clCreateProgramWithSource() => %d\n", err); return -1; }
     err = clBuildProgram(prog, 0, NULL, NULL, NULL, NULL);
+    if (err != CL_SUCCESS)
     { 
         static char log[65536]; 
         memset(log, 0, sizeof(log));

--- a/graph_app/prk/pagerank.cpp
+++ b/graph_app/prk/pagerank.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv){
 
     int num_nodes; 
     int num_edges;
-    int use_gpu = 0;
+    int use_gpu = 1;
     int file_format = 1;
     bool directed = 0;
 

--- a/graph_app/prk/pagerank.cpp
+++ b/graph_app/prk/pagerank.cpp
@@ -413,7 +413,7 @@ int shutdown()
     // release resources
     if( cmd_queue ) clReleaseCommandQueue( cmd_queue );
     if( context ) clReleaseContext( context );
-    if( device_list ) delete device_list;
+    if( device_list ) delete[] device_list;
 
     // reset all variables
     cmd_queue = 0;

--- a/graph_app/sssp/makefile
+++ b/graph_app/sssp/makefile
@@ -57,7 +57,7 @@
 include ../../common/make.config
 
 CC = g++
-CC_FLAGS = -O3 -Wall
+CC_FLAGS = -g -O3 -Wall
 
 EXE_CSR = sssp_csr
 EXE_ELL = sssp_ell

--- a/graph_app/sssp/sssp_csr.cpp
+++ b/graph_app/sssp/sssp_csr.cpp
@@ -444,7 +444,7 @@ int shutdown()
     // release resources
     if( cmd_queue ) clReleaseCommandQueue( cmd_queue );
     if( context ) clReleaseContext( context );
-    if( device_list ) delete device_list;
+    if( device_list ) delete[] device_list;
 
     // reset all variables
     cmd_queue = 0;

--- a/graph_app/sssp/sssp_csr.cpp
+++ b/graph_app/sssp/sssp_csr.cpp
@@ -138,6 +138,7 @@ int main(int argc, char **argv){
     cl_program prog = clCreateProgramWithSource(context, 1, slist, NULL, &err);
     if(err != CL_SUCCESS) { printf("ERROR: clCreateProgramWithSource() => %d\n", err); return -1; }
     err = clBuildProgram(prog, 0, NULL, NULL, NULL, NULL);
+    if (err != CL_SUCCESS)
     { // show warnings/errors
       static char log[65536]; 
       memset(log, 0, sizeof(log));

--- a/graph_app/sssp/sssp_ell.cpp
+++ b/graph_app/sssp/sssp_ell.cpp
@@ -461,7 +461,7 @@ int shutdown()
     // release resources
     if( cmd_queue ) clReleaseCommandQueue( cmd_queue );
     if( context ) clReleaseContext( context );
-    if( device_list ) delete device_list;
+    if( device_list ) delete[] device_list;
 
     // reset all variables
     cmd_queue = 0;

--- a/graph_app/sssp/sssp_ell.cpp
+++ b/graph_app/sssp/sssp_ell.cpp
@@ -148,6 +148,7 @@ int main(int argc, char **argv){
     cl_program prog = clCreateProgramWithSource(context, 1, slist, NULL, &err);
     if(err != CL_SUCCESS) { printf("ERROR: clCreateProgramWithSource() => %d\n", err); return -1; }
     err = clBuildProgram(prog, 0, NULL, NULL, NULL, NULL);
+    if (err != CL_SUCCESS)
     { // show warnings and errors
       static char log[65536]; 
       memset(log, 0, sizeof(log));

--- a/graph_parser/parse.cpp
+++ b/graph_parser/parse.cpp
@@ -281,6 +281,7 @@ csr_array *parseCOO(char* tmpchar, int *p_num_nodes, int *p_num_edges, bool dire
     csr->row_array = row_array;
     csr->col_array = col_array;
     csr->data_array = data_array;
+    csr->col_cnt = NULL;
 
     return csr;
 
@@ -583,6 +584,7 @@ csr_array *parseMM(char* tmpchar, int *p_num_nodes, int *p_num_edges, bool direc
     csr->row_array = row_array;
     csr->col_array = col_array;
     csr->data_array = data_array;
+    csr->col_cnt = NULL;
 
     return csr;
 }
@@ -800,6 +802,7 @@ csr_array *parseCOO_transpose(char* tmpchar, int *p_num_nodes, int *p_num_edges,
     csr->row_array = row_array;
     csr->col_array = col_array;
     csr->data_array = data_array;
+    csr->col_cnt = NULL;
 
     fclose(fptr);
     free(tuple_array);

--- a/graph_parser/parse.cpp
+++ b/graph_parser/parse.cpp
@@ -183,7 +183,7 @@ csr_array *parseCOO(char* tmpchar, int *p_num_nodes, int *p_num_edges, bool dire
 {
     int cnt = 0;
     unsigned int lineno = 0;
-    char line[128], sp[2], a, p;
+    char line[128], sp[3], a, p;
     int num_nodes = 0, num_edges = 0;
 
     FILE *fptr;
@@ -385,7 +385,7 @@ double_edges *parseCOO_doubleEdge(char* tmpchar, int *p_num_nodes, int *p_num_ed
 {
     int cnt = 0;
     unsigned int lineno = 0;
-    char line[128], sp[2], a, p;
+    char line[128], sp[3], a, p;
     int num_nodes = 0, num_edges = 0;
 
     FILE *fptr;
@@ -705,7 +705,7 @@ csr_array *parseCOO_transpose(char* tmpchar, int *p_num_nodes, int *p_num_edges,
 {
     int cnt = 0;
     unsigned int lineno = 0;
-    char line[128], sp[2], a, p;
+    char line[128], sp[3], a, p;
     int num_nodes = 0, num_edges = 0;
 
     FILE *fptr;


### PR DESCRIPTION
Pointers do not need to be NULL if they are not initialized. As such, not initializing col_cnt can result in a later segfault in freeArrays() because col_cnt is non-NULL but you then try to free a garbage pointer.
