### PR TITLE
PageRank: move constant load out of loop to avoid reloading it every loop iteration

### DIFF
--- a/graph_app/prk/kernel/kernel.cl
+++ b/graph_app/prk/kernel/kernel.cl
@@ -110,11 +110,12 @@ __kernel  void pagerank1(__global int *row,
            end = num_edges;
 
         int nid;
+        const float myPgRkVal = page_rank1[tid]/(float)(end-start);
 		//navigate the neighbor list
         for(int edge = start; edge < end; edge++){
             nid = col[edge];
             //transfer the PageRank value to neighbors
-            add_float_atomic(&page_rank2[nid], page_rank1[tid]/(float)(end-start));
+            add_float_atomic(&page_rank2[nid], myPgRkVal);
         }
     }
 


### PR DESCRIPTION
The loop in question is constant across all loop iterations, and thus LICM could move it out of the loop to avoid reloading it every iteration.  However, I found that some compilers (the versions that were compatible with GPGPU-Sim) were not doing this, which hurt performance by reloading the value every loop iteration.

It's a very simple fix, and may not be necessary if the compiler does LICM for it, but moving it out ensures that it will not be reloaded every loop iteration regardless of compiler.

Change-Id: Iaea37fd6aa7fb5ee95cd82fc9fd80842b786890b